### PR TITLE
Fix CSS /books/

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,6 +1,6 @@
 <style>
   .mouse-on{
-    height:auto !important;
+    height:auto;
     border-color: #66afe9;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   }


### PR DESCRIPTION
The original code is ``` height:auto !importan;```.
But I changed it to ``` height:auto !important;``` when doing indentation, so the CSS is broken.
Now I revert the CSS code back.