### PR TITLE
Can't Change Suggest Semester In Course Manage

### DIFF
--- a/app/views/course_maps/manage/xtmpl/_course_list.html.erb
+++ b/app/views/course_maps/manage/xtmpl/_course_list.html.erb
@@ -1,7 +1,7 @@
 <script type="text/x-tmpl" id="normal-course-table-tmpl">
 {% if(o.length > 0){ %}
 	{% for(var i=0,list ; list=o[i]; i++){ %}
-		<table class="table single-table no-margin-bottom">
+    <table class="table single-table no-margin-bottom" cfl_id="{%=o[i].cfl_id%}">
 			{% include("single-course-row-tmpl",list); %}
 		</table>
 	{% } %}


### PR DESCRIPTION
#### What
在回傳修改過的建議學期資料
```
Parameters: {"cfl_id"=>"11126", "type"=>"update", "target"=>"grade", "value"=>"2"}
```
給 Server 時，需要帶有 cfl_id 才能成功修改。

##### Where
在資工系的編譯器設計概論修改建議學期時發現 Bug。

##### Why
```app/assets/javascripts/course_maps/manage.js``` 的第 468 行
```var cfl_id=$table.attr("cfl_id");```
無法抓取到正確的 cfl_id。

在 ```<table class="table single-table no-margin-bottom">```中沒有 cfl_id。

##### How
在 ```app/views/course_maps/manage/xtmpl/_course_list.html.erb``` 的第 4 行加上 cfl_id。