### PR TITLE
fix replicated timeslot & add course hyper link in course table

### DIFF
--- a/app/assets/javascripts/courses/table.js
+++ b/app/assets/javascripts/courses/table.js
@@ -262,7 +262,7 @@
 							var idx_x = day-1 ;
 							var $cell = this.cells[idx_x][idx_y];
 							
-							$cell.html(course.name).addClass(course.class).selectable = false;
+							$cell.html("<a href=\"/courses/"+course.cd_id+"\" target=\"_blank\">"+course.name+"</a>").addClass(course.class).selectable = false;
 							
 							if(this.config.deletable)
 							{

--- a/app/assets/javascripts/courses/table.js
+++ b/app/assets/javascripts/courses/table.js
@@ -218,7 +218,7 @@
 			{
 				for(var j=0; j<this.cells[i].length; ++j)
 				{
-					if(this.cells[i][j].selected)
+					if(this.cells[i][j].hasClass(Table.defaults.selected_class))
 					{				
 						result.push( this.cells[i][j].time );
 					}


### PR DESCRIPTION
1. 修複第二次空堂搜尋會出現第一次空堂搜尋結果的bug(by 靖翔)，e.g. 第一次搜2CD，第二次搜3CD時會出現2CD的結果

2. 將出現在course table上的課程都加上超連結，讓使用者可以一鍵點選進入課程介紹頁，不用再回到左方的已選課程才能進入課程介紹頁