### PR TITLE
修正進階搜尋按鈕勾選問題

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');$('#q_department_id_in_string').val('');" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');deg=document.getElementById('degree');deg.value='1';change_degree($(deg));" %>
           進階搜尋
         </label>
       </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');$('#q_department_id_eq').val('');" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');$('#q_department_id_in_string').val('');" %>
           進階搜尋
         </label>
       </div>


### PR DESCRIPTION
#78 
q_department_id_eq 已經被改成 q_department_id_in_string，現在取消進階搜尋按鈕時只會更改一個不存在的DOM物件而已。