### PR TITLE
fix the problem of png data url in top frame

### DIFF
--- a/app/assets/javascripts/courses/table.js
+++ b/app/assets/javascripts/courses/table.js
@@ -144,8 +144,11 @@
 
           var dataUrl = canvas.toDataURL("image/png");
 					if (flag=="window"){
-						var exportTable = window.open();
-						exportTable.document.write(`<img src=${dataUrl} height='100%'>`);
+					        var exportTable = document.createElement('a');
+					        exportTable.href = dataUrl;
+					        exportTable.download = 'syllabus.png';
+					        blank_win = exportTable.click();
+					        blank_win.close();
 						return ;
 					}else if(flag=="url"){
 					  return dataUrl ;

--- a/app/assets/javascripts/courses/table.js
+++ b/app/assets/javascripts/courses/table.js
@@ -144,7 +144,8 @@
 
           var dataUrl = canvas.toDataURL("image/png");
 					if (flag=="window"){
-						window.open(dataUrl);
+						var exportTable = window.open();
+						exportTable.document.write(`<img src=${dataUrl} height='100%'>`);
 						return ;
 					}else if(flag=="url"){
 					  return dataUrl ;


### PR DESCRIPTION
匯出課表時原本是直接使用window.open(png_data)打開，但是因為把png的data url放在最上層的frame導致目前比較新版本的瀏覽器會產生error，所以改用<img>把url包起來再render上去