### PR TITLE
修正進階搜尋按鈕勾選問題

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');deg=document.getElementById('degree');deg.value='1';change_degree($(deg));" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');deg=document.getElementById('degree');deg.value='0';change_degree($(deg));" %>
           進階搜尋
         </label>
       </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');document.getElementById('q_semester_id_eq').value='';deg=document.getElementById('degree');deg.value='0';change_degree($(deg));" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');$('#q_semester_id_eq').val('');$('#degree').val('0');change_degree($('#degree'));" %>
           進階搜尋
         </label>
       </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');$('#q_department_id_eq').val('');" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');deg=document.getElementById('degree');deg.value='1';change_degree($(deg));" %>
           進階搜尋
         </label>
       </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,7 @@
       </div><!-- /input-group -->
       <div class="hidden-xs checkbox">
         <label style="font-size:16px;">
-          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');deg=document.getElementById('degree');deg.value='0';change_degree($(deg));" %>
+          <%=check_box_tag "adv_toggle",params[:adv_toggle],params[:adv_toggle],onchange: "$('#adv-search').toggleClass('hidden');document.getElementById('q_semester_id_eq').value='';deg=document.getElementById('degree');deg.value='0';change_degree($(deg));" %>
           進階搜尋
         </label>
       </div>

--- a/app/views/courses/search/_search_js.html.erb
+++ b/app/views/courses/search/_search_js.html.erb
@@ -10,7 +10,6 @@
     dept_sel['2']='<%=j render "courses/search/common_options" %>'
     dept_sel['3']='<%=j render "courses/search/graduate_options" %>'
     var sel_chname = {'1': '大學部', '2': '大學部共同', '3': '研究所'};
-    console.log('obj.val='+ String(obj.val()))
 
     $("#q_department_id_in_string").html(dept_sel[obj.val()]);
     $("#q_course_details_department_id_eq").html(dept_sel[obj.val()]);//if it's in course_maps/edit

--- a/app/views/courses/search/_search_js.html.erb
+++ b/app/views/courses/search/_search_js.html.erb
@@ -5,7 +5,7 @@
   }
   function change_degree(obj){
     var dept_sel=[];
-    dept_sel['0']='<option value=\"\">系所<\/option>\n<%=j render "courses/search/common_options" %>'
+    dept_sel['0']='<option value="">系所</option>\n<%=j render "courses/search/common_options" %>'
     dept_sel['1']='<%=j render "courses/search/undergrad_options" %>'
     dept_sel['2']='<%=j render "courses/search/common_options" %>'
     dept_sel['3']='<%=j render "courses/search/graduate_options" %>'

--- a/app/views/courses/search/_search_js.html.erb
+++ b/app/views/courses/search/_search_js.html.erb
@@ -5,14 +5,17 @@
   }
   function change_degree(obj){
     var dept_sel=[];
-    dept_sel['0']='';
+    dept_sel['0']='<option value=\"\">系所<\/option>\n<%=j render "courses/search/common_options" %>'
     dept_sel['1']='<%=j render "courses/search/undergrad_options" %>'
     dept_sel['2']='<%=j render "courses/search/common_options" %>'
     dept_sel['3']='<%=j render "courses/search/graduate_options" %>'
     var sel_chname = {'1': '大學部', '2': '大學部共同', '3': '研究所'};
-    if(obj.val()!="0"){
-      $("#q_department_id_in_string").html(dept_sel[obj.val()]);
-      $("#q_course_details_department_id_eq").html(dept_sel[obj.val()]);//if it's in course_maps/edit
+    console.log('obj.val='+ String(obj.val()))
+
+    $("#q_department_id_in_string").html(dept_sel[obj.val()]);
+    $("#q_course_details_department_id_eq").html(dept_sel[obj.val()]);//if it's in course_maps/edit
+
+    if(obj.val()!='0'){
       var sel_all = $("#q_department_id_in_string").children().toArray().map(function(obj) { return obj.value;}).join(" ");
       $("#q_department_id_in_string").prepend($("<option></option>")
                                      .attr("value", sel_all)


### PR DESCRIPTION
#78 

q_department_id_eq 已經被改成 q_department_id_in_string，現在取消進階搜尋按鈕時只會更改一個不存在的DOM物件而已。

新的寫法是直接再勾選/取消勾選 進階搜尋按鈕後 直接更改 分類選項中的值，再透過現有的 change_degree 函式來對開課單位進行修改。
動作上較為優雅一點。只不過仍是寫死在html文件中。