### PR TITLE
在匯入課程頁面顯示更詳細的失敗訊息

### DIFF
--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -118,16 +118,12 @@ class ScoresController < ApplicationController
                         })
 				end
 			end
-
-            puts "ERROR MESSAGES"
-            error_msgs.each do |errmsg|
-                puts "#{errmsg[:course]}: #{errmsg[:msg]}"
-            end
             
 			cm=current_user.course_maps.includes(:course_groups, :course_fields).take
 			update_cs_cfids(cm,current_user)
 			
 			outcome_msg="匯入完成! 共新增 #{@success_added} 門課 失敗:#{@fail_added} 通過:#{@pass} 退選:#{@drop} 未通過:#{@no_pass} 修習中:#{@now_taking}"
+
             session[:msg] = outcome_msg
             session[:errmsg] = error_msgs
             redirect_to :action=>:select_cf

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -67,6 +67,7 @@ class ScoresController < ApplicationController
 			@fail_added 		= 0	#匯入失敗
 			@now_taking 		= 0 #正在修
 
+
                         # Prevent the import of course will lead to the deletion of simulation
                         # Check the last import course is the last semester or not
                         # ex: LAST:105下 CURRENT:105上
@@ -79,6 +80,7 @@ class ScoresController < ApplicationController
                         if sem.id == Semester::LAST.id
                           current_user.normal_scores.destroy_all
                         end
+            err_messages = []
 
 			normal.each do |n|
 				if n['score'] == "通過" || n['score'].to_i>=current_user.pass_score
@@ -99,16 +101,34 @@ class ScoresController < ApplicationController
 						@success_added+=1
 					else
 						@fail_added+=1
+                        err_messages.append(
+                            {:sem=>"#{n['sem']}",
+                             :cos_id=>"#{n['cos_id']}",
+                             :name=>"#{n['name']}",
+                             :msg=>"課程不存在資料庫中"
+                            })
 					end
 				else
 					@fail_added+=1
+                    err_messages.append(
+                        {:sem=>"#{n['sem']}",
+                         :cos_id=>"#{n['cos_id']}",
+                         :name=>"#{n['name']}",
+                         :msg=>"尚未更新的學期資料"
+                        })
 				end
-			end		
+			end
+
+            puts "ERROR MESSAGES"
+            err_messages.each do |errmsg|
+                puts "#{errmsg[:course]}: #{errmsg[:msg]}"
+            end
+            
 			cm=current_user.course_maps.includes(:course_groups, :course_fields).take
 			update_cs_cfids(cm,current_user)
 			
 			msg="匯入完成! 共新增 #{@success_added} 門課 失敗:#{@fail_added} 通過:#{@pass} 退選:#{@drop} 未通過:#{@no_pass} 修習中:#{@now_taking}"
-			redirect_to :action=>:select_cf, :msg=>msg
+            redirect_to :action=>:select_cf, :msg=>msg, :errmsg=>err_messages
 		end
 	end
 	

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -80,7 +80,7 @@ class ScoresController < ApplicationController
                         if sem.id == Semester::LAST.id
                           current_user.normal_scores.destroy_all
                         end
-            err_messages = []
+            error_msgs = []
 
 			normal.each do |n|
 				if n['score'] == "通過" || n['score'].to_i>=current_user.pass_score
@@ -101,7 +101,7 @@ class ScoresController < ApplicationController
 						@success_added+=1
 					else
 						@fail_added+=1
-                        err_messages.append(
+                        error_msgs.append(
                             {:sem=>"#{n['sem']}",
                              :cos_id=>"#{n['cos_id']}",
                              :name=>"#{n['name']}",
@@ -110,7 +110,7 @@ class ScoresController < ApplicationController
 					end
 				else
 					@fail_added+=1
-                    err_messages.append(
+                    error_msgs.append(
                         {:sem=>"#{n['sem']}",
                          :cos_id=>"#{n['cos_id']}",
                          :name=>"#{n['name']}",
@@ -120,19 +120,23 @@ class ScoresController < ApplicationController
 			end
 
             puts "ERROR MESSAGES"
-            err_messages.each do |errmsg|
+            error_msgs.each do |errmsg|
                 puts "#{errmsg[:course]}: #{errmsg[:msg]}"
             end
             
 			cm=current_user.course_maps.includes(:course_groups, :course_fields).take
 			update_cs_cfids(cm,current_user)
 			
-			msg="匯入完成! 共新增 #{@success_added} 門課 失敗:#{@fail_added} 通過:#{@pass} 退選:#{@drop} 未通過:#{@no_pass} 修習中:#{@now_taking}"
-            redirect_to :action=>:select_cf, :msg=>msg, :errmsg=>err_messages
+			outcome_msg="匯入完成! 共新增 #{@success_added} 門課 失敗:#{@fail_added} 通過:#{@pass} 退選:#{@drop} 未通過:#{@no_pass} 修習中:#{@now_taking}"
+            session[:msg] = outcome_msg
+            session[:errmsg] = error_msgs
+            redirect_to :action=>:select_cf
 		end
 	end
 	
 	def select_cf
+        @msg = session[:msg]
+        @errmsg = session[:errmsg]
 	end
 
 	def gpa

--- a/app/views/scores/select_cf.html.erb
+++ b/app/views/scores/select_cf.html.erb
@@ -1,5 +1,24 @@
 ﻿<%= javascript_include_tag "user_course_stat/checker", "data-turbolinks-track" => true %>
 <%= javascript_include_tag "user_course_stat/cm_check-helper", "data-turbolinks-track" => true %>
+<table class="table" style="background-color:white;" >
+    <th class="">學期</th>
+    <th class="">當期課號</th>
+    <th class="">課程名稱</th>
+    <th class="">失敗原因</th>
+  <tbody>
+  <% errmsgs = params[:errmsg]%>
+  <% if not errmsgs.empty? %>
+    <% errmsgs.each do |e| %>
+        <td class=""><%= e['sem']%></td>
+        <td class=""><%= e['cos_id']%></td>
+        <td class=""><%= e['name']%></td>
+        <td class=""><%= e['msg']%></td>
+        </tr>
+    <% end %>
+  <%end%>
+  </tbody>
+</table>
+
 <div class="container panel ">
 	<div class=" bs-callout bs-callout-info well">
 		<h2><%=fa_icon "upload"%>選擇學程</h2>

--- a/app/views/scores/select_cf.html.erb
+++ b/app/views/scores/select_cf.html.erb
@@ -1,23 +1,24 @@
 ﻿<%= javascript_include_tag "user_course_stat/checker", "data-turbolinks-track" => true %>
 <%= javascript_include_tag "user_course_stat/cm_check-helper", "data-turbolinks-track" => true %>
-<table class="table" style="background-color:white;" >
-    <th class="">學期</th>
-    <th class="">當期課號</th>
-    <th class="">課程名稱</th>
-    <th class="">失敗原因</th>
-  <tbody>
-  <% errmsgs = params[:errmsg]%>
-  <% if not errmsgs.empty? %>
-    <% errmsgs.each do |e| %>
-        <td class=""><%= e['sem']%></td>
-        <td class=""><%= e['cos_id']%></td>
-        <td class=""><%= e['name']%></td>
-        <td class=""><%= e['msg']%></td>
-        </tr>
-    <% end %>
-  <%end%>
-  </tbody>
-</table>
+
+<% errmsgs = params[:errmsg]%>
+<% if errmsgs and not errmsgs.empty? %>
+    <table class="table" style="background-color:white;" >
+        <th class="">學期</th>
+        <th class="">當期課號</th>
+        <th class="">課程名稱</th>
+        <th class="">失敗原因</th>
+      <tbody>
+        <% errmsgs.each do |e| %>
+            <td class=""><%= e['sem']%></td>
+            <td class=""><%= e['cos_id']%></td>
+            <td class=""><%= e['name']%></td>
+            <td class=""><%= e['msg']%></td>
+            </tr>
+        <% end %>
+      </tbody>
+    </table>
+<%end%>
 
 <div class="container panel ">
 	<div class=" bs-callout bs-callout-info well">

--- a/app/views/scores/select_cf.html.erb
+++ b/app/views/scores/select_cf.html.erb
@@ -1,36 +1,37 @@
 ﻿<%= javascript_include_tag "user_course_stat/checker", "data-turbolinks-track" => true %>
 <%= javascript_include_tag "user_course_stat/cm_check-helper", "data-turbolinks-track" => true %>
-
-<% errmsgs = params[:errmsg]%>
-<% if errmsgs and not errmsgs.empty? %>
-    <table class="table" style="background-color:white;" >
-        <th class="">學期</th>
-        <th class="">當期課號</th>
-        <th class="">課程名稱</th>
-        <th class="">失敗原因</th>
-      <tbody>
-        <% errmsgs.each do |e| %>
-            <td class=""><%= e['sem']%></td>
-            <td class=""><%= e['cos_id']%></td>
-            <td class=""><%= e['name']%></td>
-            <td class=""><%= e['msg']%></td>
-            </tr>
-        <% end %>
-      </tbody>
-    </table>
-<%end%>
-
-<div class="container panel ">
-	<div class=" bs-callout bs-callout-info well">
-		<h2><%=fa_icon "upload"%>選擇學程</h2>
-		<h4>
-			<%=params[:msg]%><br>
-			請選擇以下課程的所屬學程
-		</h4>	
-	</div>
+<div class="container panel">
+    <% if @msg %>
+        <h3><%= @msg %><br></h3>
+        <% if @errmsg and not @errmsg.empty? %>
+            <div class=" bs-callout bs-callout-danger well">
+                <h2>匯入失敗課程</h2>
+                <table class="table" style="background-color:white;" >
+                    <th class="">學期</th>
+                    <th class="">當期課號</th>
+                    <th class="">課程名稱</th>
+                    <th class="">失敗原因</th>
+                  <tbody>
+                    <% @errmsg.each do |e| %>
+                        <td class=""><%= e[:sem]%></td>
+                        <td class=""><%= e[:cos_id]%></td>
+                        <td class=""><%= e[:name]%></td>
+                        <td class=""><%= e[:msg]%></td>
+                        </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+            小提醒: 請幫忙回報您的錯誤訊息給<a target="_blank" href="https://www.facebook.com/nctuplus/">NCTU+團隊</a>以方便進行修復，謝謝!
+            </div>
+        <%end%>
+    <%end%>
+    <div class=" bs-callout bs-callout-info well">
+        <h2><%=fa_icon "upload"%>選擇學程</h2>
+        <h4>請選擇以下課程的所屬學程</h4>	
+        <div id="course_list" class=""></div>
+    </div>
 	<div id="common_check_div" class=""></div>
 	<div id="cosmap_check_div" class=""></div>
-	<div id="course_list" class=""></div>
 </div>
 
 <script>
@@ -56,5 +57,6 @@ $(document).ready(function(){
 <% if current_user.is_undergrad? %>
 	<%=render :partial=>"/user/course_stat/xtmpl_common_check"%>
 <% end %>
+
 <%=render :partial=>"/user/course_stat/xtmpl_cm_check"%>
 <%=render :partial=>"/user/xtmpl_select_cf"%>


### PR DESCRIPTION
做了四點更動
1. 回傳訊息時改使用  rails的 session 變數來儲存訊息，簡化原本回傳的超長url欄位
2. 將後端回傳的訊息(匯入完成! ....) 從選擇學程區塊中拆出來，讓不同區塊更具有主題性
3. 顯示匯入失敗的課程，並告知使用者匯入失敗的原因
4. 將選擇學程的欄位跟需要選擇的地方直接放在一起，而不是如原本的分拆在頁面最上跟最下兩個不同的區塊

更改前
![before](https://user-images.githubusercontent.com/13212935/39969094-ae9cb604-5709-11e8-8eb7-cb53d3e883f9.png)

更改後
![after](https://user-images.githubusercontent.com/13212935/39969097-b4a0cea0-5709-11e8-8867-f101d159bae6.png)
