### PR TITLE
課程收藏功能修復

### DIFF
--- a/app/assets/javascripts/courses/cart.js
+++ b/app/assets/javascripts/courses/cart.js
@@ -28,7 +28,7 @@ function add_to_cart($this_but, id,type){
 //  參數介紹:
 //      success(data): 成功拿取時的callback function.
 //          data: 拿到的使用者收藏課程(json)
-function show_cart_json(success){
+function fetch_user_cart(success){
     $.ajax({
         type:'GET',
         url:'/courses/show_cart?view_type=session&use_type=delete&add_to_cart=0',

--- a/app/assets/javascripts/courses/cart.js
+++ b/app/assets/javascripts/courses/cart.js
@@ -32,6 +32,8 @@ function fetch_user_cart(success){
         headers:{
             'Content-Type':'application/json'
         }
-    }).done(res=>success(res))
+    }).done(
+        function(res){success(res);}
+    )
 }
 

--- a/app/assets/javascripts/courses/cart.js
+++ b/app/assets/javascripts/courses/cart.js
@@ -4,21 +4,21 @@
  *
  * For courses shopping cart
  *
- * Modified at 2015/6/17
+ * Modified at 2018/5/28
  */
 
 function add_to_cart($this_but, id,type){
-	$.ajax({
-		type: "GET",
-		url : "/courses/add_to_cart",
-		data : {
-			cd_id:id,
-			type:type
-		},
-		success : function(data){
+    $.ajax({
+        type: "GET",
+        url : "/courses/add_to_cart",
+        data : {
+            cd_id:id,
+            type:type
+        },
+        success : function(data){
             toastr[String(data.class)]( String(data.text) );
-		}
-	});
+        }
+    });
 }
 
 // 拿取使用者的收藏課程(json格式)

--- a/app/assets/javascripts/courses/cart.js
+++ b/app/assets/javascripts/courses/cart.js
@@ -16,12 +16,9 @@ function add_to_cart($this_but, id,type){
 			type:type
 		},
 		success : function(data){
-			toastr[data.class](data.text);
+            toastr[String(data.class)]( String(data.text) );
 		}
 	});
-	if (type == 'delete')
-            $this_but.parent().parent().parent().parent().remove();
-
 }
 
 // 拿取使用者的收藏課程(json格式)

--- a/app/assets/javascripts/courses/cart.js
+++ b/app/assets/javascripts/courses/cart.js
@@ -24,3 +24,17 @@ function add_to_cart($this_but, id,type){
 
 }
 
+// 拿取使用者的收藏課程(json格式)
+//  參數介紹:
+//      success(data): 成功拿取時的callback function.
+//          data: 拿到的使用者收藏課程(json)
+function show_cart_json(success){
+    $.ajax({
+        type:'GET',
+        url:'/courses/show_cart?view_type=session&use_type=delete&add_to_cart=0',
+        headers:{
+            'Content-Type':'application/json'
+        }
+    }).done(res=>success(res))
+}
+

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -178,7 +178,11 @@ class CoursesController < ApplicationController
         cd.to_search_result
       }
     }
-    render :layout=>false
+    respond_to do |format|
+        format.json{ render :json => @result[:courses].to_json}
+        format.html{ render :layout=>false}
+    end
+    #render :layout=>false
   end
 
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -182,7 +182,6 @@ class CoursesController < ApplicationController
         format.json{ render :json => @result[:courses].to_json}
         format.html{ render :layout=>false}
     end
-    #render :layout=>false
   end
 
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,5 +1,11 @@
-<br>
+<%= javascript_include_tag "courses/cart", "data-turbolinks-track" => true %>
+
 <%=render 'courses/search/search_js' %>
+
+<script>
+    function print_result(data){console.log(data)};
+</script>
+<button onclick="show_cart_json(print_result)">拿取收藏課程</button>
 
 <%= search_form_for @q, url:"/courses/", class:"form-inline" do |f| %>
   <div class="row">	

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -46,10 +46,10 @@
     <th class="">學分</th>
     <th class="">時間</th>
     <th class="">年級</th>
+
     <th class="hidden-xs">收藏</th>
   </tr>
   <tbody >
-  <% cd_ids=cookies.signed[:cd].nil? ? [] : JSON.parse(cookies.signed[:cd]) %>
   <% if !@cds.empty? %>
     <% @cds.each do |cd| %>
         <tr id="<%=cd.id%>" class="row clickable-row clickable-hover" href="<%=course_path(cd.id)%>">
@@ -65,11 +65,7 @@
           <td class=""><%= cd.time %></td>
           <td class=""> <%=cd.grade%> </td>
           <td class="hidden-xs" id="check-<%=cd.id%>" onclick="">
-            <% type=cd_ids.present?&&cd_ids.include?(cd.id) ? "delete":"add" %>
-            <%=fa_icon type=="add" ? "square-o 2x" :"check-square-o 2x", style:"color:lightseagreen;", data: type,class:"cart-control"%>
-
-          </td>
-          
+            <%=fa_icon "square-o 2x", style:"color:lightseagreen;", data:"add",class:"cart-control"%>
         </tr>
     <% end %>
   <% else %>
@@ -85,32 +81,40 @@
 <%= paginate @cds, :window=>2 %>
 
 <script>
-    let user_course_id_cart = new Set();
 
-    function update_user_cart_set(data){
-        data.forEach(element => user_course_id_cart.add(String(element.id) ))
-    };
-    function update_check_box(){
-        let coursearray = $('tr.clickable-row').get();
-        coursearray.forEach( element =>{
-            let box = $("#check-"+element.id+" i:first-child" );
-            if( user_course_id_cart.has(element.id) ){
-                box.removeClass("fa-square-o").addClass("fa-check-square-o");
-                box.attr("data", "delete");
-            }else{
-                box.removeClass("fa-check-square-o").addClass("fa-square-o");
-                box.attr("data", "add");
-            }
-        })
-    };
-  $(document).ready( function(){
-      fetch_user_cart( data => {
-          update_user_cart_set(data);
-          update_check_box();
-      });
-  });
+    //更改收藏課表的icon狀態，順便向後端發出請求
+    // @new_state(boolean)
+    set_checkbox = function(course_id, new_state){
+        let checkbox = $("#check-"+course_id+" i:first-child" );
+        if(new_state === true){
+            checkbox.removeClass("fa-square-o").addClass("fa-check-square-o");
+            checkbox.attr("data", "delete");
+        }else if (new_state === false){
+            checkbox.removeClass("fa-check-square-o").addClass("fa-square-o");
+            checkbox.attr("data", "add");
+        }else{
+            console.log( "Error: new_state must be one of 'true' or 'false'");
+        }
+    }
 
   $(function(){
+
+    // 初始化收藏課程勾選狀態
+     <% if current_user  %>
+        fetch_user_cart( data => {
+            let fav_courses_set = new Set();
+            data.forEach(element => fav_courses_set.add(String(element.id)));
+
+            let course_list = $('tr.clickable-row').get();
+            course_list.forEach( element =>{
+                if( fav_courses_set.has(element.id) ){
+                    set_checkbox( element.id, true);
+                }else{
+                    set_checkbox( element.id, false);
+                }
+            })
+        });
+    <% end %>
     
     change_degree($("#degree"));
     $("#q_department_id_eq").val('<%=@q.department_id_eq%>');
@@ -132,16 +136,20 @@
         });
       },
       click:function(){//add or delete cart
-        add_to_cart($(this), $(this).parent().parent().attr("id"),$(this).attr("data"));
-        var type=$(this).attr("data");
-        if(type=="add"){
-          $(this).attr("data","delete");
-          $(this).toggleClass("fa-square-o fa-check-square-o");
-        }
-        else{
-          $(this).attr("data","add");
-          $(this).toggleClass("fa-check-square-o fa-square-o");
-        }
+        <% if current_user%>
+            add_to_cart($(this), $(this).parent().parent().attr("id"),$(this).attr("data"));
+            var type=$(this).attr("data");
+            if(type=="add"){
+              $(this).attr("data","delete");
+              $(this).toggleClass("fa-square-o fa-check-square-o");
+            }
+            else{
+              $(this).attr("data","add");
+              $(this).toggleClass("fa-check-square-o fa-square-o");
+            }
+        <% else %>
+            toastr["error"]("請先登入");
+        <%end%>
       }
     });
     //toastr["success"]("已更新暑修課程囉，請利用進階搜尋查詢~");

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -2,10 +2,6 @@
 
 <%=render 'courses/search/search_js' %>
 
-<script>
-    function print_result(data){console.log(data)};
-</script>
-<button onclick="fetch_user_cart(print_result)">拿取收藏課程</button>
 
 <%= search_form_for @q, url:"/courses/", class:"form-inline" do |f| %>
   <div class="row">	
@@ -50,8 +46,9 @@
     <th class="">學分</th>
     <th class="">時間</th>
     <th class="">年級</th>
+    <th class="hidden-xs">收藏</th>
   </tr>
-  <tbody>
+  <tbody >
   <% cd_ids=cookies.signed[:cd].nil? ? [] : JSON.parse(cookies.signed[:cd]) %>
   <% if !@cds.empty? %>
     <% @cds.each do |cd| %>
@@ -66,8 +63,11 @@
           <td class=""><%= cd.teacher_name %></td>
           <td class=""><%= cd.course_credit %></td>
           <td class=""><%= cd.time %></td>
-          <td class="">
-            <%=cd.grade%>
+          <td class=""> <%=cd.grade%> </td>
+          <td class="hidden-xs" id="check-<%=cd.id%>" onclick="">
+            <% type=cd_ids.present?&&cd_ids.include?(cd.id) ? "delete":"add" %>
+            <%=fa_icon type=="add" ? "square-o 2x" :"check-square-o 2x", style:"color:lightseagreen;", data: type,class:"cart-control"%>
+
           </td>
           
         </tr>
@@ -85,6 +85,31 @@
 <%= paginate @cds, :window=>2 %>
 
 <script>
+    let user_course_id_cart = new Set();
+
+    function update_user_cart_set(data){
+        data.forEach(element => user_course_id_cart.add(String(element.id) ))
+    };
+    function update_check_box(){
+        let coursearray = $('tr.clickable-row').get();
+        coursearray.forEach( element =>{
+            let box = $("#check-"+element.id+" i:first-child" );
+            if( user_course_id_cart.has(element.id) ){
+                box.removeClass("fa-square-o").addClass("fa-check-square-o");
+                box.attr("data", "delete");
+            }else{
+                box.removeClass("fa-check-square-o").addClass("fa-square-o");
+                box.attr("data", "add");
+            }
+        })
+    };
+  $(document).ready( function(){
+      fetch_user_cart( data => {
+          update_user_cart_set(data);
+          update_check_box();
+      });
+  });
+
   $(function(){
     
     change_degree($("#degree"));
@@ -106,8 +131,8 @@
           goToHref($(this).attr("href"),false);
         });
       },
-      click:function(){	//add or delete cart
-        add_to_cart($(this).parent().parent().attr("id"),$(this).attr("data"));
+      click:function(){//add or delete cart
+        add_to_cart($(this), $(this).parent().parent().attr("id"),$(this).attr("data"));
         var type=$(this).attr("data");
         if(type=="add"){
           $(this).attr("data","delete");

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -5,7 +5,7 @@
 <script>
     function print_result(data){console.log(data)};
 </script>
-<button onclick="show_cart_json(print_result)">拿取收藏課程</button>
+<button onclick="fetch_user_cart(print_result)">拿取收藏課程</button>
 
 <%= search_form_for @q, url:"/courses/", class:"form-inline" do |f| %>
   <div class="row">	

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -2,7 +2,6 @@
 
 <%=render 'courses/search/search_js' %>
 
-
 <%= search_form_for @q, url:"/courses/", class:"form-inline" do |f| %>
   <div class="row">	
     <div class="col-md-12 col-sm-12 col-xs-12 text-center">
@@ -46,7 +45,6 @@
     <th class="">學分</th>
     <th class="">時間</th>
     <th class="">年級</th>
-
     <th class="hidden-xs">收藏</th>
   </tr>
   <tbody >
@@ -66,6 +64,7 @@
           <td class=""> <%=cd.grade%> </td>
           <td class="hidden-xs" id="check-<%=cd.id%>" onclick="">
             <%=fa_icon "square-o 2x", style:"color:lightseagreen;", data:"add",class:"cart-control"%>
+          </td>
         </tr>
     <% end %>
   <% else %>

--- a/app/views/courses/search/_xtmpl_results_mini.html.erb
+++ b/app/views/courses/search/_xtmpl_results_mini.html.erb
@@ -103,7 +103,8 @@
                                 <button title="加選" class="btn btn-success btn-circle " onclick="addCourseSimulation($(this), {%=cd.id%}, '{%=cd.time%}', 'add','search')">
                                     <span class="glyphicon glyphicon-plus"></span>
                                 </button>
-                                <button title="取消收藏課程" class="btn btn-warning btn-circle" onclick="add_to_cart($(this), {%=cd.id%},'delete')">
+                                <button title="取消收藏課程" class="btn btn-warning btn-circle" onclick="add_to_cart($(this), {%=cd.id%},'delete'); $(this).parent().parent().parent().parent().remove(); ">
+     
                                     <span class="glyphicon glyphicon-minus"></span>
                                 </button>
                             {% } %}


### PR DESCRIPTION
主要重點:
 重新整合模擬排課跟全校課程兩區的課程收藏功能

修改記事:
 1.修改了API讓add_cart函式只負責向後端傳資料，而不包含更改瀏覽器DOM的行為
 2.將全校課程瀏覽中的蒐藏課程動作包成單一函式，方便未來開發 (全部收藏/全部取消) 之類的功能。

![selection_002](https://user-images.githubusercontent.com/13212935/40621978-e18b428c-62d1-11e8-8839-e6aa9a813150.png)
![selection_003](https://user-images.githubusercontent.com/13212935/40621980-e2fb8a00-62d1-11e8-8b06-8e41a329e220.png)
![selection_004](https://user-images.githubusercontent.com/13212935/40621981-e49bad2c-62d1-11e8-8d2d-8c6c817d3ca2.png)
