### PR TITLE
修復課程心得編輯功能

### DIFF
--- a/app/controllers/discusses_controller.rb
+++ b/app/controllers/discusses_controller.rb
@@ -108,10 +108,12 @@ class DiscussesController < ApplicationController
 	
 	def destroy
 		if params[:type].blank?
+            # 刪除心得，以及相關的留言
 			@discuss=current_user.discusses.find(params[:id])
 			@discuss.destroy!
 			redirect_to :action=> :index
 		elsif params[:type]=="sub"
+            # 單純刪除留言
 			@sub_d=current_user.sub_discusses.find(params[:id])
 			#@sub_d_id=@discuss.discuss_id
 			@sub_d.destroy!

--- a/app/models/discuss.rb
+++ b/app/models/discuss.rb
@@ -6,7 +6,6 @@ class Discuss < ActiveRecord::Base
 	has_many :departments, :through=>:course_details
 	has_many :colleges, :through=>:departments
 	#has_many :discuss_verifies, :dependent => :destroy
-	#has_many :discuss_likes, :dependent => :destroy
 	has_many :sub_discusses, :dependent => :destroy
 	delegate :uid, :to=>:user, :prefix=>true
 	delegate :ch_name, :to=>:course, :prefix=>true

--- a/app/models/sub_discuss.rb
+++ b/app/models/sub_discuss.rb
@@ -1,7 +1,6 @@
 class SubDiscuss < ActiveRecord::Base
 	belongs_to :discuss
 	belongs_to :user
-	has_many :discuss_likes, :dependent => :destroy
 	#delegate :name,:uid, :to=>:user, :prefix=>true
 	validates_presence_of :content, :user_id, :discuss_id
 	def owner_name

--- a/app/views/discusses/_modal_content.html.erb
+++ b/app/views/discusses/_modal_content.html.erb
@@ -107,7 +107,7 @@
 			//alert("!!!");
 		}
 		//$container.find("[name='sub_discuss[is_anonymous]']").val(anonymous);
-		$("#delte_sub_but").attr("href","/discusses/"+id+"?type=sub");
+		$("#delete_sub_but").attr("href","/discusses/"+id+"?type=sub");
 	}
 	function toggleAvatar($obj){
 		$container=$obj.parent().parent().parent().parent();

--- a/app/views/discusses/_sub_form.html.erb
+++ b/app/views/discusses/_sub_form.html.erb
@@ -23,7 +23,7 @@
 		<% if action=="create"%>
 			<br>
 		<% else %>
-			<%= link_to '刪除', "", :method => :delete, :data => { :confirm => "確認刪除?" },class:"btn  btn-danger",id:"delte_sub_but",remote:"true" %>
+			<%= link_to '刪除', "", :method => :delete, :data => { :confirm => "確認刪除?" },class:"btn  btn-danger",id:"delete_sub_but",remote:"true" %>
 		<% end %>
 		<%= f.submit "送出", :class=>"btn btn-primary " %>
 	</div>


### PR DESCRIPTION
修正 #107 
已用 production mode 測試完畢

這裡面牽扯到很早的一份程式碼，而當初有一個 table 叫做`discuss_likes`
刪除資料表的紀錄在 `nctuplus/db/migrate/20160116070010_remove_useless_tables.rb`
而`discuss_likes`被移除之後由於沒修改sub_discuss model 中指定的相依性，造成無法成功移除留言。

