### PR TITLE
課程搜尋顯示新制通識

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -21,35 +21,35 @@ class CoursesController < ApplicationController
         
         # 舊制通識
         if not cd.brief.strip.empty?
-            str = cd.brief.sub(/\(\s*\d+\s*\)/,'')
-            str.strip!
-            if not str.empty?
-                tags_of_a_course.append( {:name=> str, :title=>cd.brief, :label_type=>'label-default'} )
+            # 移除資料後綴年份 e.g. "體育必修(87)"-> "體育必修"
+            trimmed_name = cd.brief.sub(/\(\s*\d+\s*\)/,'').strip
+            if not trimmed_name.empty?
+                tags_of_a_course.append( {:name=> trimmed_name, :title=>cd.brief, :label_type=>'label-default'} )
             end
         end
 
-        # 針對新制通識 
+        # 針對新制通識
+        #   abbrev: abbreviation
         abbrev_dict = {
             :校基本素養 => { :name=> '通識校基本', :label_type=>'label-primary'},
             :跨院基本素養 => { :name=> '通識跨院', :label_type=>'label-info'}
         }
-            # 移除後綴年份別ex. "跨院基本素養(106)"-> "跨院基本素養"
 
         # 測試用
-        test_str = "核心-自然(106),跨院基本素養(106),校基本素養(106)"
-        str = test_str.sub(/\(\s*\d+\s*\)/,'')
+        brief_str = "核心-自然(106),跨院基本素養(106),校基本素養(106)"
 
-        str_array = str.split(',')
-        str_array.each do |str|
-            full_name = str.sub(/\(\s*\d+\s*\)/,'')
-            full_name = full_name.to_sym
-            puts "full name #{full_name}"
-            if abbrev_dict.key?(full_name)
-                h = abbrev_dict[full_name]
-                h[:title] = str 
+        #brief_str = cd.brief_new
+        brief_str_array = brief_str.split(',')
+        brief_str_array.each do |full_name|
+            str = full_name.sub(/\(\s*\d+\s*\)/,'').to_sym
+            trimmed_name = full_name.sub(/\(\s*\d+\s*\)/,'').to_sym
+            if abbrev_dict.key?(trimmed_name)
+                h = abbrev_dict[trimmed_name]
+                h[:title] = full_name
                 tags_of_a_course.append(h)
             else
-                tags_of_a_course.append( {:name=>full_name,:title=>str, :label_type=>'label-default'} )
+                # 核心類別
+                tags_of_a_course.append( {:name=>trimmed_name,:title=>full_name, :label_type=>'label-warning'} )
             end
         end
         if not tags_of_a_course.empty?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -41,7 +41,6 @@ class CoursesController < ApplicationController
         brief_str = cd.brief_new
         brief_str_array = brief_str.split(',')
         brief_str_array.each do |full_name|
-            str = full_name.sub(/\(\s*\d+\s*\)/,'').to_sym
             trimmed_name = full_name.sub(/\(\s*\d+\s*\)/,'').to_sym
             if abbrev_dict.key?(trimmed_name)
                 h = abbrev_dict[trimmed_name]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -36,9 +36,9 @@ class CoursesController < ApplicationController
         }
 
         # 測試用
-        brief_str = "核心-自然(106),跨院基本素養(106),校基本素養(106)"
+        #brief_str = "核心-自然(106),跨院基本素養(106),校基本素養(106)"
 
-        #brief_str = cd.brief_new
+        brief_str = cd.brief_new
         brief_str_array = brief_str.split(',')
         brief_str_array.each do |full_name|
             str = full_name.sub(/\(\s*\d+\s*\)/,'').to_sym

--- a/app/models/course_detail.rb
+++ b/app/models/course_detail.rb
@@ -95,6 +95,7 @@ class CourseDetail < ActiveRecord::Base
     cd.students_limit=data["num_limit"]
     cd.reg_num=data["reg_num"]
     cd.brief=data["brief"]
+    cd.brief_new = data.key?("brief_new") ? data["brief_new"] : ""
     cd.save!
     return ret
   end

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -61,8 +61,8 @@
 
               <% if @tags_by_id.key?( cd.id )%>
                   </br>
-                  <% c_tags = @tags_by_id[cd.id]%>
-                  <% c_tags.each do |tag| %>
+                  <% info_tags = @tags_by_id[cd.id]%>
+                  <% info_tags.each do |tag| %>
                       <span class="label <%= tag[:label_type]%> general-edu-info" data-toggle="tooltip" data-placement="bottom" title="<%=tag[:title]%>"> <%=tag[:name]%></span>
                   <% end %>
               <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -39,9 +39,9 @@
 <table class="table table-hover" id="course_table" style="background-color:white;" >
   <tr class="row">
     <th class="hidden-xs">學期</th>
-    <th class="hidden-xs">系所/摘要</th>
     <th class="">課名</th>
     <th class="">老師</th>
+    <th class="hidden-xs">系所/摘要</th>
     <th class="">學分</th>
     <th class="">時間</th>
     <th class="">年級</th>
@@ -54,11 +54,35 @@
           <td class="hidden-xs">
             <%=cd.semester_name%>
           </td>
-          <td class="hidden-xs">
-            <%="#{cd.department_ch_name} #{cd.brief}"%>
-          </td>
           <td class=""><%= cd.course_ch_name %></td>
           <td class=""><%= cd.teacher_name %></td>
+          <td class="hidden-xs">
+              <%="#{cd.department_ch_name}" %>
+              <% if cd.brief %>
+                  </br>
+                  <% line_breaked = true%>
+                  <span class="label general-edu-info"><%= "#{cd.brief}" %></span>
+              <% end %>
+
+              <% if true %>
+                  <% if not line_breaked %>
+                    </br>
+                  <% end %>
+                <% text = "核心-自然(106),跨院基本素養(106),校基本素養(106)" %>
+                <% li = text.split(',') %>
+                <% li.each do |item| %>
+                    <span class="label general-edu-info"><%="#{item}"%></span>
+                <% end %>
+
+              <% end %>
+
+              <% if false %>
+                </br> 
+                <span class="label general-edu-info">公民/進階(96)</span>
+                <span class="label general-edu-info">校基本素養(106)</span>
+                <span class="label general-edu-info">跨院基本素養(106)</span>
+              <%end%>
+          </td>
           <td class=""><%= cd.course_credit %></td>
           <td class=""><%= cd.time %></td>
           <td class=""> <%=cd.grade%> </td>
@@ -81,6 +105,36 @@
 
 <script>
 
+    //移除通識課程後的年份標籤
+    remove_appended_year = function(str){
+        return  str.replace(/\(\s*\d+\s*\)/gm, "" );
+    }
+    generate_brief_name = function(str){
+        var dict = {
+            '校基本素養':'通識校基本',
+            '跨院基本素養':'通識跨院'
+        };
+        return (str in dict) ? dict[str] : str; 
+    }
+    append_brief_class_by_name = function(name){
+        var dict = {
+            "通識校基本":"label-primary",
+            "通識跨院":"label-info"
+        }
+        return (name in dict) ? dict[name] :'label-default' ; 
+    }
+    function brief_general_edu_info()
+    {
+        x=document.getElementsByClassName("general-edu-info");
+        for(var i = 0; i < x.length; i++){
+            var text = x[i].innerText;
+            text = remove_appended_year(text);
+            text = generate_brief_name(text);
+            x[i].innerText = text;
+            x[i].classList.add( append_brief_class_by_name(text)  );
+        }
+    }
+
     //更改收藏課表的icon狀態，順便向後端發出請求
     // @new_state(boolean)
     set_checkbox = function(course_id, new_state){
@@ -97,7 +151,10 @@
     }
 
   $(function(){
+    //簡化通識課程的類別摘要
+    brief_general_edu_info();
 
+    //$("#test-target").innerHTML =  remove_year( $("#test-target").innerHTML );
     // 初始化收藏課程勾選狀態
      <% if current_user  %>
         fetch_user_cart( data => {

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -104,7 +104,6 @@
     }
 
   $(function(){
-    //$("#test-target").innerHTML =  remove_year( $("#test-target").innerHTML );
     // 初始化收藏課程勾選狀態
      <% if current_user  %>
         fetch_user_cart( data => {

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -58,30 +58,14 @@
           <td class=""><%= cd.teacher_name %></td>
           <td class="hidden-xs">
               <%="#{cd.department_ch_name}" %>
-              <% if cd.brief %>
+
+              <% if @tags_by_id.key?( cd.id )%>
                   </br>
-                  <% line_breaked = true%>
-                  <span class="label general-edu-info"><%= "#{cd.brief}" %></span>
-              <% end %>
-
-              <% if true %>
-                  <% if not line_breaked %>
-                    </br>
+                  <% c_tags = @tags_by_id[cd.id]%>
+                  <% c_tags.each do |tag| %>
+                      <span class="label <%= tag[:label_type]%> general-edu-info" data-toggle="tooltip" data-placement="bottom" title="<%=tag[:title]%>"> <%=tag[:name]%></span>
                   <% end %>
-                <% text = "核心-自然(106),跨院基本素養(106),校基本素養(106)" %>
-                <% li = text.split(',') %>
-                <% li.each do |item| %>
-                    <span class="label general-edu-info"><%="#{item}"%></span>
-                <% end %>
-
               <% end %>
-
-              <% if false %>
-                </br> 
-                <span class="label general-edu-info">公民/進階(96)</span>
-                <span class="label general-edu-info">校基本素養(106)</span>
-                <span class="label general-edu-info">跨院基本素養(106)</span>
-              <%end%>
           </td>
           <td class=""><%= cd.course_credit %></td>
           <td class=""><%= cd.time %></td>
@@ -104,37 +88,6 @@
 <%= paginate @cds, :window=>2 %>
 
 <script>
-
-    //移除通識課程後的年份標籤
-    remove_appended_year = function(str){
-        return  str.replace(/\(\s*\d+\s*\)/gm, "" );
-    }
-    generate_brief_name = function(str){
-        var dict = {
-            '校基本素養':'通識校基本',
-            '跨院基本素養':'通識跨院'
-        };
-        return (str in dict) ? dict[str] : str; 
-    }
-    append_brief_class_by_name = function(name){
-        var dict = {
-            "通識校基本":"label-primary",
-            "通識跨院":"label-info"
-        }
-        return (name in dict) ? dict[name] :'label-default' ; 
-    }
-    function brief_general_edu_info()
-    {
-        x=document.getElementsByClassName("general-edu-info");
-        for(var i = 0; i < x.length; i++){
-            var text = x[i].innerText;
-            text = remove_appended_year(text);
-            text = generate_brief_name(text);
-            x[i].innerText = text;
-            x[i].classList.add( append_brief_class_by_name(text)  );
-        }
-    }
-
     //更改收藏課表的icon狀態，順便向後端發出請求
     // @new_state(boolean)
     set_checkbox = function(course_id, new_state){
@@ -151,9 +104,6 @@
     }
 
   $(function(){
-    //簡化通識課程的類別摘要
-    brief_general_edu_info();
-
     //$("#test-target").innerHTML =  remove_year( $("#test-target").innerHTML );
     // 初始化收藏課程勾選狀態
      <% if current_user  %>

--- a/db/migrate/20180901234443_add_brief_new_to_course_detail.rb
+++ b/db/migrate/20180901234443_add_brief_new_to_course_detail.rb
@@ -1,0 +1,5 @@
+class AddBriefNewToCourseDetail < ActiveRecord::Migration
+  def change
+		add_column :course_details, :brief_new, :string
+  end
+end


### PR DESCRIPTION
# 更改事項
1. 更改匯入課表程式碼 - 在 `course_details`資料表 中新增 `brief_new`欄位，因應新的API

2. 修改全校課程搜尋的畫面。
首先新增新制通識的標籤，並將過去的摘要也標籤化。還有把搜尋結果的`系所/摘要`欄位往後挪，平衡整體頁面的比重。

# 注意
因為沒有資料庫的修改權限，所以全程都是以自己輸入的假資料做開發。 必須要先db:migrate 並 匯入新課表驗證後才能保證正確性

# 預覽
原本的畫面
![screen shot 2018-09-02 at 9 01 37 am](https://user-images.githubusercontent.com/13212935/44957634-802e9080-af06-11e8-8c5f-780bdf4286c1.png)

更改後的顯示頁面
![screen shot 2018-09-02 at 11 17 49 pm](https://user-images.githubusercontent.com/13212935/44957635-83298100-af06-11e8-9248-fd6a23c9287b.png)
