### PR TITLE
Fix wrong course link

### DIFF
--- a/app/views/course_content/_course_info.html.erb
+++ b/app/views/course_content/_course_info.html.erb
@@ -15,7 +15,7 @@
 		<tr>
 			<td><%=cd.semester.name%></td>
 			<td><%=cd.department.ch_name%></td>
-			<td><%=link_to cd.temp_cos_id,"https://cos.adm.nctu.edu.tw/Course/CrsOutline/show.asp?Acy=#{cd.semester.year}&Sem=#{cd.semester.half}&CrsNo=#{cd.temp_cos_id}", target:"_blank"%></td>
+			<td><%=link_to cd.temp_cos_id,"https://course.nctu.edu.tw/Course/CrsOutline/show.asp?Acy=#{cd.semester.year}&Sem=#{cd.semester.half}&CrsNo=#{cd.temp_cos_id}", target:"_blank"%></td>
 			<td>							
 				<% if cd.cos_type=="通識"%>
 					<%=cd.brief%>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21094580/50583709-d9eb9b00-0ea5-11e9-9b48-45548bbc973b.png)
* 課號的連結原本是連結到 `cos.adm.nctu.edu.tw` 這個host，但因為此host的TLS設定有問題，故將連結換至 `course.nctu.edu.tw` 此host，這樣課號的連結與課程綱要的連結也是一致的